### PR TITLE
Fixed csv field_size_limit function call

### DIFF
--- a/triqler/triqler.py
+++ b/triqler/triqler.py
@@ -104,7 +104,7 @@ def parseArgs():
     sys.exit("ERROR: --min_samples should be >= 2")
 
   if args.csv_field_size_limit is not None:
-    csv.set_field_size_limit(args.csv_field_size_limit)
+    csv.field_size_limit(args.csv_field_size_limit)
   
   return args, params
   


### PR DESCRIPTION
I realized that #16 included a typo in the function call to set the CSV field size limit.

There is no `set_field_size_limit`, and it should be `field_size_limit` ([docs](https://docs.python.org/3/library/csv.html#csv.field_size_limit)).

@MatthewThe Could you provide your environment that you use to run the tests? I'd be willing to write a test, but I think our environments are slightly different.